### PR TITLE
Now set -c and -n flags take priority over default values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,8 +40,8 @@ const [
   legacyClientCommand = defaultNpmCommand
 ] = args.sub;
 
-const npmClient = legacyNpmClient || flags.npmClient;
-const clientCommand = legacyClientCommand || flags.npmClientCommand;
+const npmClient = flags.npmClient || legacyNpmClient;
+const clientCommand = flags.npmClientCommand || legacyClientCommand;
 
 if (!scope) {
   args.showHelp();


### PR DESCRIPTION
Set -c and -n flags were being ignored.